### PR TITLE
Glob file system to locate substitution variations

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,6 @@
 		"QUnit": true,
 		"steal": true,
 		"System": true,
-		"Promise": true,
-		"console": true
+		"define": true
 	}
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -16,14 +16,12 @@
 	"smarttabs": true,
 	"maxerr" : 200,
 	"browser": true,
+	"node": true,
 	"globals": {
 		"QUnit": true,
 		"steal": true,
 		"System": true,
-		"module": true,
-		"require": true,
 		"Promise": true,
-		"console": true,
-		"exports": true
+		"console": true
 	}
 }

--- a/conditional.js
+++ b/conditional.js
@@ -131,6 +131,39 @@ define(['module'], function(module) {
 							.then(function(variations) {
 								var promises = [];
 
+								/*
+								 * With an conditional import like this:
+								 *
+								 * import 'locate/#{lang}';
+								 *
+								 * and an app tree that looks like the one below:
+								 *
+								 * locale
+								 * ├── ar.js
+								 * ├── en.js
+								 * ├── es.js
+								 * ├── hi.js
+								 * └── zh.js
+								 *
+								 * `variations` will be an array of the files
+								 * relative to the `locale` folder, e.g:
+								 *
+								 * `['ar.js', 'en.js', 'es.js', 'hi.js', 'zh.js']`
+								 *
+								 * we iterate over the array, remove the extension,
+								 * then take the original module name with the
+								 * substitution syntax and replace it with the
+								 * variation name, after this we get the following
+								 * modules names:
+								 *
+								 * `['locale/ar', 'local/en', ..., 'locale/zh']`
+								 *
+								 * We run each of those module names through the
+								 * `normalize` hook to handle any relative paths,
+								 * and finally we add them to `loader.bundle` (if
+								 * not added already) to make sure we get bundles
+								 * for each variation when the app is built.
+								 */
 								for (var i = 0; i < variations.length; i += 1) {
 									var variation = variations[i].replace(".js", "");
 									var modName = nameWithConditional.replace(conditionalRegEx, variation);

--- a/conditional.js
+++ b/conditional.js
@@ -1,234 +1,234 @@
-"format cjs";
+define(['module'], function(module) {
 
-function addConditionals(loader) {
-	var conditionalRegEx = /#\{[^\}]+\}|#\?.+$/;
+	function addConditionals(loader) {
+		var conditionalRegEx = /#\{[^\}]+\}|#\?.+$/;
 
-	var isNode = typeof process === "object" &&
-		{}.toString.call(process) === "[object process]";
+		var isNode = typeof process === "object" &&
+			{}.toString.call(process) === "[object process]";
 
-	if (loader._extensions) {
-		loader._extensions.push(addConditionals);
-	}
-
-	loader.set("@@conditional-helpers", loader.newModule({
-		isConditionalModuleName: function(moduleName){
-			return conditionalRegEx.test(moduleName);
-		}
-	}));
-
-	var normalize = loader.normalize;
-
-	function readMemberExpression(p, value) {
-		var pParts = p.split(".");
-		while (pParts.length) {
-			value = value[pParts.shift()];
-		}
-		return value;
-	}
-
-	function includeInBuild(loader, name) {
-		var load = loader.getModuleLoad(name);
-		load.metadata.includeInBuild = true;
-	}
-
-	// get some node modules through @node-require which is a noop in the browser
-	function getGlob() {
-		if (isNode) {
-			return loader.import("@node-require", { name: module.id })
-			.then(function(nodeRequire) {
-				return nodeRequire("glob");
-			});
+		if (loader._extensions) {
+			loader._extensions.push(addConditionals);
 		}
 
-		return Promise.resolve();
-	}
+		loader.set("@@conditional-helpers", loader.newModule({
+			isConditionalModuleName: function(moduleName){
+				return conditionalRegEx.test(moduleName);
+			}
+		}));
 
-	loader.normalize = function(name, parentName, parentAddress, pluginNormalize) {
-		var loader = this;
+		var normalize = loader.normalize;
 
-		var conditionalMatch = name.match(conditionalRegEx);
-		if (conditionalMatch) {
-			var substitution = conditionalMatch[0][1] !== "?";
+		function readMemberExpression(p, value) {
+			var pParts = p.split(".");
+			while (pParts.length) {
+				value = value[pParts.shift()];
+			}
+			return value;
+		}
 
-			var conditionModule = substitution ?
-				conditionalMatch[0].substr(2, conditionalMatch[0].length - 3) :
-				conditionalMatch[0].substr(2);
+		function includeInBuild(loader, name) {
+			var load = loader.getModuleLoad(name);
+			load.metadata.includeInBuild = true;
+		}
 
-			if (conditionModule[0] === "." || conditionModule.indexOf("/") !== -1) {
-				throw new TypeError(
-					"Invalid condition " +
-					conditionalMatch[0] +
-					"\n\tCondition modules cannot contain . or / in the name."
-				);
+		// get some node modules through @node-require which is a noop in the browser
+		function getGlob() {
+			if (isNode) {
+				return loader.import("@node-require", { name: module.id })
+					.then(function(nodeRequire) {
+						return nodeRequire("glob");
+					});
 			}
 
-			var conditionExport = "default";
-			var conditionExportIndex = conditionModule.indexOf(".");
+			return Promise.resolve();
+		}
 
-			if (conditionExportIndex !== -1) {
-				conditionExport = conditionModule.substr(conditionExportIndex + 1);
-				conditionModule = conditionModule.substr(0, conditionExportIndex);
-			}
+		loader.normalize = function(name, parentName, parentAddress, pluginNormalize) {
+			var loader = this;
 
-			var booleanNegation = !substitution && conditionModule[0] === "~";
-			if (booleanNegation) {
-				conditionModule = conditionModule.substr(1);
-			}
+			var conditionalMatch = name.match(conditionalRegEx);
+			if (conditionalMatch) {
+				var substitution = conditionalMatch[0][1] !== "?";
 
-			var handleConditionalBuild = function() {};
+				var conditionModule = substitution ?
+					conditionalMatch[0].substr(2, conditionalMatch[0].length - 3) :
+					conditionalMatch[0].substr(2);
 
-			//!steal-remove-start
-			handleConditionalBuild = function() {
-				var setBundlesPromise = Promise.resolve();
+				if (conditionModule[0] === "." || conditionModule.indexOf("/") !== -1) {
+					throw new TypeError(
+						"Invalid condition " +
+							conditionalMatch[0] +
+							"\n\tCondition modules cannot contain . or / in the name."
+					);
+				}
 
-				// make sure loader.bundle is an array
-				loader.bundle = typeof loader.bundle === "undefined" ?
-					[] : loader.bundle;
+				var conditionExport = "default";
+				var conditionExportIndex = conditionModule.indexOf(".");
 
-				if (substitution) {
-					var glob = null;
-					var nameWithConditional = name;
+				if (conditionExportIndex !== -1) {
+					conditionExport = conditionModule.substr(conditionExportIndex + 1);
+					conditionModule = conditionModule.substr(0, conditionExportIndex);
+				}
 
-					// remove the conditional and the trailing slash
-					var nameWithoutConditional = name
-						.replace(conditionalRegEx, "")
-						.replace(/\/+$/, "");
+				var booleanNegation = !substitution && conditionModule[0] === "~";
+				if (booleanNegation) {
+					conditionModule = conditionModule.substr(1);
+				}
 
-					setBundlesPromise = getGlob()
-					.then(function(nodeGlob) {
-						// in the browser we don't load the node modules
-						if (!nodeGlob) {
-							throw new Error("glob module not loaded");
-						}
+				var handleConditionalBuild = function() {};
 
-						// make glob available down the pipeline
-						glob = nodeGlob;
+				//!steal-remove-start
+				handleConditionalBuild = function() {
+					var setBundlesPromise = Promise.resolve();
 
-						return normalize.call(loader, nameWithoutConditional,
-							parentName, parentAddress, pluginNormalize);
-					})
-					.then(function(normalized) {
-						return loader.locate({ name: normalized + "/*", metadata: {} });
-					})
-					.then(function(address) {
-						var path = address.replace("file:", "");
-						var parts = path.split("/");
-						var pattern = parts.pop();
+					// make sure loader.bundle is an array
+					loader.bundle = typeof loader.bundle === "undefined" ?
+						[] : loader.bundle;
 
-						return new Promise(function(resolve, reject) {
-							var options = {
-								cwd: parts.join("/"),
-								dot: true, nobrace: true, noglobstar: true,
-								noext: true, nodir: true
-							};
+					if (substitution) {
+						var glob = null;
+						var nameWithConditional = name;
 
-							glob(pattern, options, function(err, files) {
-								if (err) { reject(err); }
-								resolve(files);
-							});
-						});
-					})
-					.then(function(variations) {
-						var promises = [];
+						// remove the conditional and the trailing slash
+						var nameWithoutConditional = name
+							.replace(conditionalRegEx, "")
+							.replace(/\/+$/, "");
 
-						for (var i = 0; i < variations.length; i += 1) {
-							var variation = variations[i].replace(".js", "");
-							var modName = nameWithConditional.replace(conditionalRegEx, variation);
-
-							var promise = loader.normalize.call(loader, modName,
-								parentName, parentAddress, pluginNormalize);
-
-							promises.push(promise.then(function(normalized) {
-								var isBundle = loader.bundle.indexOf(normalized) !== -1;
-
-								if (!isBundle) {
-									loader.bundle.push(normalized);
+						setBundlesPromise = getGlob()
+							.then(function(nodeGlob) {
+								// in the browser we don't load the node modules
+								if (!nodeGlob) {
+									throw new Error("glob module not loaded");
 								}
-							}));
+
+								// make glob available down the pipeline
+								glob = nodeGlob;
+
+								return normalize.call(loader, nameWithoutConditional,
+									parentName, parentAddress, pluginNormalize);
+							})
+							.then(function(normalized) {
+								return loader.locate({ name: normalized + "/*", metadata: {} });
+							})
+							.then(function(address) {
+								var path = address.replace("file:", "");
+								var parts = path.split("/");
+								var pattern = parts.pop();
+
+								return new Promise(function(resolve, reject) {
+									var options = {
+										cwd: parts.join("/"),
+										dot: true, nobrace: true, noglobstar: true,
+										noext: true, nodir: true
+									};
+
+									glob(pattern, options, function(err, files) {
+										if (err) { reject(err); }
+										resolve(files);
+									});
+								});
+							})
+							.then(function(variations) {
+								var promises = [];
+
+								for (var i = 0; i < variations.length; i += 1) {
+									var variation = variations[i].replace(".js", "");
+									var modName = nameWithConditional.replace(conditionalRegEx, variation);
+
+									var promise = loader.normalize.call(loader, modName,
+										parentName, parentAddress, pluginNormalize);
+
+									promises.push(promise.then(function(normalized) {
+										var isBundle = loader.bundle.indexOf(normalized) !== -1;
+
+										if (!isBundle) {
+											loader.bundle.push(normalized);
+										}
+									}));
+								}
+
+								return Promise.all(promises);
+							});
+					}
+					// boolean conditional syntax
+					else {
+						loader.bundle.push(name.replace(conditionalRegEx, ""));
+					}
+
+					name = "@empty";
+					return setBundlesPromise.then(function() {
+						return normalize.call(loader, name, parentName,
+							parentAddress, pluginNormalize);
+					});
+				};
+				//!steal-remove-end
+
+				var handleConditionalEval = function(m) {
+					var conditionValue = (typeof m === "object") ?
+						readMemberExpression(conditionExport, m) : m;
+
+					if (substitution) {
+						if (typeof conditionValue !== "string") {
+							throw new TypeError(
+								"The condition value for " +
+									conditionalMatch[0] +
+									" doesn't resolve to a string."
+							);
 						}
 
-						return Promise.all(promises);
-					});
-				}
-				// boolean conditional syntax
-				else {
-					loader.bundle.push(name.replace(conditionalRegEx, ""));
-				}
-
-				name = "@empty";
-				return setBundlesPromise.then(function() {
-					return normalize.call(loader, name, parentName,
-						parentAddress, pluginNormalize);
-				});
-			};
-			//!steal-remove-end
-
-			var handleConditionalEval = function(m) {
-				var conditionValue = (typeof m === "object") ?
-					readMemberExpression(conditionExport, m) : m;
-
-				if (substitution) {
-					if (typeof conditionValue !== "string") {
-						throw new TypeError(
-							"The condition value for " +
-							conditionalMatch[0] +
-							" doesn't resolve to a string."
-						);
+						name = name.replace(conditionalRegEx, conditionValue);
+					}
+					else {
+						if (typeof conditionValue !== "boolean") {
+							throw new TypeError(
+								"The condition value for " +
+									conditionalMatch[0] +
+									" isn't resolving to a boolean."
+							);
+						}
+						if (booleanNegation) {
+							conditionValue = !conditionValue;
+						}
+						if (!conditionValue) {
+							name = "@empty";
+						} else {
+							name = name.replace(conditionalRegEx, "");
+						}
 					}
 
-					name = name.replace(conditionalRegEx, conditionValue);
-				}
-				else {
-					if (typeof conditionValue !== "boolean") {
-						throw new TypeError(
-							"The condition value for " +
-							conditionalMatch[0] +
-							" isn't resolving to a boolean."
-						);
-					}
-					if (booleanNegation) {
-						conditionValue = !conditionValue;
-					}
-					if (!conditionValue) {
-						name = "@empty";
+					if (name === "@empty") {
+						return normalize.call(loader, name, parentName, parentAddress, pluginNormalize);
 					} else {
-						name = name.replace(conditionalRegEx, "");
+						// call the full normalize in case the module name
+						// is an npm package (that needs to be normalized)
+						return loader.normalize.call(loader, name, parentName, parentAddress, pluginNormalize);
 					}
-				}
+				};
 
-				if (name === "@empty") {
-					return normalize.call(loader, name, parentName, parentAddress, pluginNormalize);
-				} else {
-					// call the full normalize in case the module name
-					// is an npm package (that needs to be normalized)
-					return loader.normalize.call(loader, name, parentName, parentAddress, pluginNormalize);
-				}
-			};
+				var pluginLoader = loader.pluginLoader || loader;
+				return pluginLoader["import"](conditionModule, parentName, parentAddress)
+					.then(function(m) {
+						return pluginLoader
+							.normalize(conditionModule, parentName, parentAddress, pluginNormalize)
+							.then(function(fullName) {
+								includeInBuild(pluginLoader, fullName);
+								return m;
+							});
+					})
+					.then(function(m) {
+						var isBuild = (loader.env || "").indexOf("build") === 0;
 
-			var pluginLoader = loader.pluginLoader || loader;
-			return pluginLoader["import"](conditionModule, parentName, parentAddress)
-			.then(function(m) {
-				return pluginLoader
-					.normalize(conditionModule, parentName, parentAddress, pluginNormalize)
-					.then(function(fullName) {
-						includeInBuild(pluginLoader, fullName);
-						return m;
+						return isBuild ?
+							handleConditionalBuild() :
+							handleConditionalEval(m);
 					});
-			})
-			.then(function(m) {
-				var isBuild = (loader.env || "").indexOf("build") === 0;
+			}
 
-				return isBuild ?
-					handleConditionalBuild() :
-					handleConditionalEval(m);
-			});
-		}
+			return Promise.resolve(normalize.call(loader, name, parentName, parentAddress, pluginNormalize));
+		};
+	}
 
-		return Promise.resolve(normalize.call(loader, name, parentName, parentAddress, pluginNormalize));
-	};
-}
-
-if (typeof System !== "undefined") {
-	addConditionals(System);
-}
-
+	if (typeof System !== "undefined") {
+		addConditionals(System);
+	}
+});

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
   "homepage": "https://github.com/stealjs/conditional",
   "devDependencies": {
     "jshint": "^2.9.1",
-    "steal": "^1.0.0-rc.10",
+    "steal": "^1.0.0-rc.11",
     "steal-css": "^1.0.0-rc.0",
     "steal-qunit": "^0.1.1",
     "testdouble": "^1.4.1",
-    "testee": "^0.2.5"
+    "testee": "^0.2.5",
+    "glob": "^7.1.1"
   },
   "system": {
     "transpiler": "babel",

--- a/test/substitution.js
+++ b/test/substitution.js
@@ -83,51 +83,6 @@ QUnit.module("with valid es6 substitution module export", function(hooks) {
 			   testConditionModuleInBuild);
 });
 
-QUnit.module("if substitution module exports a 'cases' property", function(hooks) {
-	var env;
-
-	hooks.beforeEach(function() {
-		env = loader.env;
-
-		loader.env = "build-development";
-
-		td.replace(loader, "getModuleLoad", function() {
-			return { metadata: {} };
-		});
-
-		td.replace(loader, "import", function(conditionModule) {
-			var m = {default: "chrome", cases: ["chrome", "ie"]};
-
-			return conditionModule === "browser" ?
-				Promise.resolve(m) :
-				Promise.reject();
-		});
-	});
-
-	hooks.afterEach(function() {
-		td.reset();
-		loader.env = env;
-	});
-
-	QUnit.test("adds the 'cases' modules to the bundles if building code", function(assert) {
-		var done = assert.async();
-
-		// browser.hasFoo must be a boolean
-		loader.normalize("jquery/#{browser}")
-			.then(function(name) {
-				assert.ok(loader.bundle.indexOf("jquery/ie") !== -1);
-				assert.ok(loader.bundle.indexOf("jquery/chrome") !== -1);
-				assert.ok(name, "@empty");
-				done();
-			})
-			.catch(function(err) {
-				assert.notOk(err, "should not fail");
-				done();
-			});
-	});
-});
-
-
 function testInvalidSubstitutionModuleExport(assert) {
 	var done = assert.async();
 
@@ -147,7 +102,7 @@ function testInvalidSubstitutionModuleExport(assert) {
 function testValidSubstitutionExport(assert) {
 	var done = assert.async();
 
-	// browser must default export a string
+	// browser's default export must be a string
 	loader.normalize("jquery/#{browser}")
 		.then(function(name) {
 			assert.equal(name, "jquery/chrome");
@@ -162,7 +117,6 @@ function testValidSubstitutionExport(assert) {
 function testConditionModuleInBuild(assert) {
 	var done = assert.async();
 
-	// browser.hasFoo must be a boolean
 	loader.normalize("jquery/#{browser}")
 		.then(function(name) {
 			var load = loader.getModuleLoad("browser");


### PR DESCRIPTION
Closes #22 

so @matthewp I have a couple of issues getting to work this:

- In production mode, steal tries to load `path` and `glob`. I added them to `npmIgnore` but that doesn't seem to work;  here is a branch on the sample app https://github.com/m-mujica/steal-conditional-interpolation-example/tree/new-conditional, I wonder how can I prevent steal to try to load them

![screen shot 2016-11-24 at 16 19 47](https://cloud.githubusercontent.com/assets/724877/20608581/df608692-b261-11e6-9c29-5b158dfb78ad.png)

  
- I get a different error when I use relative imports, for some reason steal doesn't look for the conditionally loaded modules in the bundles folder but in `dist/{module_name}` https://github.com/m-mujica/steal-conditional-interpolation-example/tree/relative-import

do you see anything in the code that might be easier to approach in a different way? 