### PR TITLE
Run substitution module identifier through full normalize

### DIFF
--- a/conditional.js
+++ b/conditional.js
@@ -104,7 +104,10 @@ define(['module'], function(module) {
 								// make glob available down the pipeline
 								glob = nodeGlob;
 
-								return normalize.call(loader, nameWithoutConditional,
+								// call the full normalize in case the condition
+								// module is using the tilde lookup scheme or the
+								// package name
+								return loader.normalize.call(loader, nameWithoutConditional,
 									parentName, parentAddress, pluginNormalize);
 							})
 							.then(function(normalized) {


### PR DESCRIPTION
This way, module identifiers using the `~` scheme (or the package name) are normalized appropriately by the `npm-extension` before `steal-conditional` uses it to glob the file system to detect the substitution variations

I wasn't sure how to write a test in steal-conditional, in steal-tools was easy to replicate though https://github.com/stealjs/steal-tools/pull/584

Fixes #31