### PR TITLE
Add conditionDependencies metadata to load objects

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
 script: npm test
 sudo: false
 addons:
-  firefox: "43.0"
+  firefox: "59.0"


### PR DESCRIPTION
This adds conditionDependencies to load object, an array of normalized
names. This is so that during tree-shaking we know not to remove these
modules. Closes #55