### PR TITLE
Use @loader

### DIFF
--- a/conditional.js
+++ b/conditional.js
@@ -1,4 +1,4 @@
-define(["module", "exports"], function(module, exports) {
+define(["module", "exports", "@loader"], function(module, exports, System) {
 	exports.extensionBuilder = "steal-conditional/slim";
 
 	function addConditionals(loader) {


### PR DESCRIPTION
Depending on the global `System` can cause race conditions where the
extension might be applied to one loader but not another if the `System`
is not pointing to the correct loader at the time the module body
executes.

Fixes https://github.com/donejs/donejs/issues/1160